### PR TITLE
Update loot.txt for minicore

### DIFF
--- a/mods/minicore/engine/loot.txt
+++ b/mods/minicore/engine/loot.txt
@@ -4,3 +4,18 @@ loot_animation=0,0,32,64
 loot_animation_offset=16,56
 
 tooltip_margin=16
+
+# Autopickup
+autopickup_range=48
+autopickup_currency=1
+
+# Currency
+currency_name=Gold
+vendor_ratio=25
+
+# currency loot ranges
+# values are: filename, lower limit, upper limit
+# -1 can be used for the upper limit to set no upper limit
+currency_range=coins5,0,9
+currency_range=coins25,10,24
+currency_range=coins100,25,-1


### PR DESCRIPTION
I think the lack of currency_range values was causing a segfault for only the minicore mod. This appears to fix it, so it will do for now. But there may be some engine code that can be changed to prevent accidental cases of this.

Also, this scales down the auto pickup range, so it's the same relative distance as in the full size mod.
