### PR TITLE
Rename XP and gold tags for item bonuses

### DIFF
--- a/mods/fantasycore/items/items.txt
+++ b/mods/fantasycore/items/items.txt
@@ -663,7 +663,7 @@ sfx=cloth
 gfx=cloth_gloves
 loot_animation=clothes
 price=5
-bonus=gold,25
+bonus=gold find,25
 
 
 

--- a/mods/fantasycore/menus/character.txt
+++ b/mods/fantasycore/menus/character.txt
@@ -54,5 +54,7 @@ show_melee=1
 show_ranged=1
 show_crit=1
 show_absorb=1
+show_bonus_xp=1
+show_bonus_currency=1
 show_resists=1
 

--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1125,7 +1125,7 @@ effect_additive=true
 [power]
 id=222
 name=XP(bonus)
-tag=XP
+tag=XP gain
 type=effect
 effect_type=xp
 effect_additive=true
@@ -1133,7 +1133,7 @@ effect_additive=true
 [power]
 id=223
 name=Gold (bonus)
-tag=gold
+tag=gold find
 type=effect
 effect_type=currency
 effect_additive=true


### PR DESCRIPTION
"gold find" and "XP gain" make more sense when displayed in tooltips

Also, update menus/character.txt to show xp/gold bonuses. (see clintbellanger/flare-engine#265)
