### PR TITLE
Fix Out-of-Control Effects

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1033,7 +1033,7 @@ name=HP (bonus)
 tag=HP
 type=effect
 effect_type=hp
-effect_additive=true
+effect_additive=false
 
 [power]
 id=211
@@ -1041,7 +1041,7 @@ name=HP Regen (bonus)
 tag=HP regen
 type=effect
 effect_type=hp_regen
-effect_additive=true
+effect_additive=false
 
 [power]
 id=212
@@ -1049,7 +1049,7 @@ name=MP (bonus)
 tag=MP
 type=effect
 effect_type=mp
-effect_additive=true
+effect_additive=false
 
 [power]
 id=213
@@ -1057,7 +1057,7 @@ name=MP Regen (bonus)
 tag=MP regen
 type=effect
 effect_type=mp_regen
-effect_additive=true
+effect_additive=false
 
 [power]
 id=214
@@ -1065,7 +1065,7 @@ name=Accuracy (bonus)
 tag=accuracy
 type=effect
 effect_type=accuracy
-effect_additive=true
+effect_additive=false
 
 [power]
 id=215
@@ -1073,7 +1073,7 @@ name=Avoidance (bonus)
 tag=avoidance
 type=effect
 effect_type=avoidance
-effect_additive=true
+effect_additive=false
 
 [power]
 id=216
@@ -1081,7 +1081,7 @@ name=Crit (bonus)
 tag=crit
 type=effect
 effect_type=crit
-effect_additive=true
+effect_additive=false
 
 [power]
 id=217
@@ -1096,7 +1096,7 @@ name=Offense (bonus)
 tag=offense
 type=effect
 effect_type=offense
-effect_additive=true
+effect_additive=false
 
 [power]
 id=219
@@ -1104,7 +1104,7 @@ name=Defense (bonus)
 tag=defense
 type=effect
 effect_type=defense
-effect_additive=true
+effect_additive=false
 
 [power]
 id=220
@@ -1112,7 +1112,7 @@ name=Physical (bonus)
 tag=physical
 type=effect
 effect_type=physical
-effect_additive=true
+effect_additive=false
 
 [power]
 id=221
@@ -1120,7 +1120,7 @@ name=Mental (bonus)
 tag=mental
 type=effect
 effect_type=mental
-effect_additive=true
+effect_additive=false
 
 [power]
 id=222
@@ -1128,7 +1128,7 @@ name=XP(bonus)
 tag=XP gain
 type=effect
 effect_type=xp
-effect_additive=true
+effect_additive=false
 
 [power]
 id=223
@@ -1136,7 +1136,7 @@ name=Gold (bonus)
 tag=gold find
 type=effect
 effect_type=currency
-effect_additive=true
+effect_additive=false
 
 [power]
 id=224
@@ -1144,7 +1144,7 @@ name=Fire Resistance (bonus)
 tag=fire resist
 type=effect
 effect_type=fire_resist
-effect_additive=true
+effect_additive=false
 
 [power]
 id=225
@@ -1152,7 +1152,7 @@ name=Ice Resistance (bonus)
 tag=ice resist
 type=effect
 effect_type=ice_resist
-effect_additive=true
+effect_additive=false
 
 [power]
 id=226


### PR DESCRIPTION
If effect_additive is set to true on a stat, that stat will increase by the effect magnitude with every engine tick, eg, your bonus XP will increase by 10% every tick, giving you 300% bonus XP after one second in-game.
