### PR TITLE
[Galician Translation] ouro → moedas

### DIFF
--- a/mods/fantasycore/languages/data.gl.po
+++ b/mods/fantasycore/languages/data.gl.po
@@ -7,9 +7,9 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2012-09-26 20:07+\n"
-"PO-Revision-Date: 2012-10-27 18:06+0200\n"
-"Last-Translator: Adrián Chaves Fernández <adriyetichaves@gmail.com>\n"
-"Language-Team: Galician <kde-i18n-doc@kde.org>\n"
+"PO-Revision-Date: 2012-12-26 18:32+0100\n"
+"Last-Translator: Adrian Chaves Fernandez <adriyetichaves@gmail.com>\n"
+"Language-Team: Galician <proxecto@trasno.net>\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2974,7 +2974,7 @@ msgstr "Resistencia á luz."
 
 #: ../engine/loot.txt:15
 msgid "Gold"
-msgstr "ouro"
+msgstr "moedas"
 
 #: ../enemies/antlion.txt:1
 msgid "Antlion"


### PR DESCRIPTION
“Gold” is used in the game as the name of the monetary unit. You can get “20 Gold”, for example. In this context, the right translation would probably be “moedas” (coins) instead of “ouro”.

PS: Sorry for not pushing this change with the previous one, I somehow assumed the change was going to be needed on the engine instead, where I will shortly request another pull for “dende → desde”.
