### PR TITLE
Fix enemy groups in Lost Mines

### DIFF
--- a/mods/alpha_demo/maps/lost_mines1.txt
+++ b/mods/alpha_demo/maps/lost_mines1.txt
@@ -592,29 +592,29 @@ location=56,62,1,1
 type=undead
 location=6,11,21,35
 level=3,3
-number=10
+number=10,10
 
 [enemygroup]
 type=undead
 location=6,11,21,35
 level=4,5
-number=5
+number=5,5
 
 [enemygroup]
 type=undead
 location=15,49,33,12
 level=3,5
-number=6
+number=6,6
 
 [enemygroup]
 type=antlion
 location=66,55,24,18
 level=4,6
-number=6
+number=6,6
 
 [enemygroup]
 type=antlion_hatchling
 location=91,57,2,4
 level=2,6
-number=5
+number=5,5
 

--- a/tiled/averguard/lost_mine.tmx
+++ b/tiled/averguard/lost_mine.tmx
@@ -553,31 +553,31 @@
   <object type="undead" x="192" y="352" width="672" height="1120">
    <properties>
     <property name="level" value="3,3"/>
-    <property name="number" value="10"/>
+    <property name="number" value="10,10"/>
    </properties>
   </object>
   <object type="undead" x="192" y="352" width="672" height="1120">
    <properties>
     <property name="level" value="4,5"/>
-    <property name="number" value="5"/>
+    <property name="number" value="5,5"/>
    </properties>
   </object>
   <object type="undead" x="480" y="1568" width="1056" height="384">
    <properties>
     <property name="level" value="3,5"/>
-    <property name="number" value="6"/>
+    <property name="number" value="6,6"/>
    </properties>
   </object>
   <object type="antlion" x="2112" y="1760" width="768" height="576">
    <properties>
     <property name="level" value="4,6"/>
-    <property name="number" value="6"/>
+    <property name="number" value="6,6"/>
    </properties>
   </object>
   <object type="antlion_hatchling" x="2912" y="1824" width="64" height="128">
    <properties>
     <property name="level" value="2,6"/>
-    <property name="number" value="5"/>
+    <property name="number" value="5,5"/>
    </properties>
   </object>
  </objectgroup>


### PR DESCRIPTION
The `number` key requires 2 values now, a min and a max. For each group, I
made the min and the max the same, which I think should mimic the old
behavior. As far as I know, this is the only map that was broken this way.
