### PR TITLE
Add Norwegian Bokmål to the list of languages in the fantasycore mod too

### DIFF
--- a/mods/fantasycore/engine/languages.txt
+++ b/mods/fantasycore/engine/languages.txt
@@ -9,6 +9,7 @@ fr=Français
 gl=Galego
 it=Italiano
 ja=Nihongo
+nb=Norsk Bokmål
 nl=Nederlands
 pl=Polski
 ru=Русский


### PR DESCRIPTION
Slightly longer explanation:
A while back I translated parts of the engine, adding a new .po file and adding nb to the list of languages. But when the latest engine changes were synced to the game recently, I couldn't find Norwegian Bokmål in the list of languages.

However, I realized that if I disabled the fantasycore mod, it would appear in the list. The reason seem to be fantasycore's languages.txt which overrides default's. From what I can see, both lists need to be updated for a new language to always be available in the menu. Is this intentional, for instance to allow adding new languages to a game without having to include it in the engine first, or a bug? 
