### PR TITLE
Make Averguard quests more flexible

### DIFF
--- a/mods/alpha_demo/enemies/professor_langlier.txt
+++ b/mods/alpha_demo/enemies/professor_langlier.txt
@@ -7,7 +7,7 @@ animations=skeleton_mage
 
 
 # langlier's talisman
-quest_loot=ak_talisman_search,ak_talisman_found,9002
+quest_loot=ak_tome_reward,ak_talisman_found,9002
 
 # combat stats
 hp=200

--- a/mods/alpha_demo/enemies/the_warden.txt
+++ b/mods/alpha_demo/enemies/the_warden.txt
@@ -8,7 +8,7 @@ speed=150
 
 
 # averguard key
-quest_loot=ak_key_search,ak_key_found,9001
+quest_loot=ak_tome_reward,ak_key_found,9001
 
 # combat stats
 hp=280

--- a/mods/alpha_demo/maps/averguard_temple.txt
+++ b/mods/alpha_demo/maps/averguard_temple.txt
@@ -8,13 +8,13 @@ tileset=tileset_dungeon.txt
 title=Averguard Temple
 
 [tilesets]
-tileset=../../../../flare-game/tiled/dungeon/tiled_collision.png,64,32,0,0
-tileset=../../../../flare-game/tiled/dungeon/tiled_dungeon.png,64,128,0,0
-tileset=../../../../flare-game/tiled/dungeon/set_rules.png,64,32,0,0
-tileset=../../../../flare-game/tiled/dungeon/tiled_dungeon_2x2.png,128,64,0,16
-tileset=../../../../flare-game/tiled/dungeon/door_left.png,64,128,-16,-8
-tileset=../../../../flare-game/tiled/dungeon/door_right.png,64,128,16,-8
-tileset=../../../../flare-game/tiled/dungeon/stairs.png,256,256,0,48
+tileset=../../../tiled/dungeon/tiled_collision.png,64,32,0,0
+tileset=../../../tiled/dungeon/tiled_dungeon.png,64,128,0,0
+tileset=../../../tiled/dungeon/set_rules.png,64,32,0,0
+tileset=../../../tiled/dungeon/tiled_dungeon_2x2.png,128,64,0,16
+tileset=../../../tiled/dungeon/door_left.png,64,128,-16,-8
+tileset=../../../tiled/dungeon/door_right.png,64,128,16,-8
+tileset=../../../tiled/dungeon/stairs.png,256,256,0,48
 
 [layer]
 type=background
@@ -447,8 +447,8 @@ location=15,88,1,1
 hotspot=location
 msg=You insert the Averguard Key. Runes glow around the door, then fade. The door is still sealed.
 requires_item=9001
-requires_not=ak_maddox_search
-requires_status=ak_temple_search
+requires_not=ak_talisman_found
+requires_status=ak_key_found
 set_status=ak_temple_sealed
 tooltip=Sealed Temple Door
 
@@ -459,7 +459,7 @@ location=13,89,1,1
 hotspot=15,88,1,1
 msg=You read aloud the runes on Langlier's Talisman. The Avergard Key begins to glow!
 requires_not=ak_talisman_used
-requires_status=ak_maddox_search
+requires_status=ak_key_found,ak_talisman_found
 set_status=ak_talisman_used
 shakycam=60
 soundfx=soundfx/powers/quake.ogg

--- a/mods/alpha_demo/npcs/guill.txt
+++ b/mods/alpha_demo/npcs/guill.txt
@@ -36,7 +36,9 @@ him=Ukkonen is defeated -- I sensed a calm in this place the moment you ended hi
 
 [dialog]
 topic=Averguard Chronicles
+requires_status=ak_intro
 requires_not=ak_tome_found
+set_status=ak_tome_search
 him=The Averguard left a set of Chronicles detailing their final era. One volume is missing. I've searched this entire area except for Ukkonen's lair. If you find the book please return to me.
 you=I'll keep an eye out for it.
 
@@ -77,6 +79,7 @@ him=A true shame that he was infected.  Well, now that we have the Averguard Key
 topic=Burial Chamber
 requires_status=ak_key_reward
 requires_not=ak_temple_sealed
+requires_not=ak_talisman_used
 set_status=ak_temple_search
 him=There is one place within the Keep that no living being has seen for centuries: the burial chamber behind Averguard Temple. From the Atrium you can access the Temple. Use your key to enter the Burial Chamber.
 you=Who is buried there?
@@ -99,10 +102,10 @@ him=I must admit jealousy -- I have dreamed many years of seeing the old volumes
 [dialog]
 topic=Langlier's Talisman
 requires_status=ak_talisman_found
+requires_not=ak_talisman_reward
 requires_item=9002
 you=I am back from the Academy. Langlier was rags and bones, yet still a powerful mage. He wore this symbol.
 set_status=ak_talisman_reward
-set_status=ak_maddox_search
 reward_xp=250
 reward_currency=125
 him=Fate has delivered this talisman to you. With it and the Averguard Key, you have the ability to open the Burial Chamber. Read these runes aloud at the sealed door and the path will be opened.
@@ -110,12 +113,16 @@ him=Fate has delivered this talisman to you. With it and the Averguard Key, you 
 [dialog]
 topic=Sir Evan Maddox
 requires_not=ak_maddox_defeated
-requires_status=ak_talisman_reward
+requires_status=ak_key_found
+requires_status=ak_talisman_found
+set_status=ak_maddox_search
 him=My worst fear is come alive. Just as with the Warden and with Professor Langlier, Sir Evan Maddox himself was inflicted with undeath. If we are to reclaim the Keep, you must defeat him. The Order will reward you magnificently for this service. But be prepared -- not even undeath will limit Maddox's zeal. Enter the Burial Chamber and allow him redemption.
 
 [dialog]
 topic=Maddox defated
 requires_status=ak_maddox_defeated
+requires_status=ak_key_reward
+requires_status=ak_talisman_reward
 requires_not=ak_maddox_reward
 set_status=ak_maddox_reward
 remove_item=9001

--- a/mods/alpha_demo/quests/averguard_keep.txt
+++ b/mods/alpha_demo/quests/averguard_keep.txt
@@ -13,7 +13,7 @@ requires_not=ak_ukkonen_reward
 quest_text=Report your victory over Ukkonen to Guill in the Goblin Warrens.
 
 [quest]
-requires_status=ak_ukkonen_reward
+requires_status=ak_tome_search
 requires_not=ak_tome_found
 quest_text=Search Ukkonen's lair in the Goblin Warrens for a missing Averguard Tome.
 
@@ -35,6 +35,7 @@ quest_text=Tell Guill that you have found the Averguard Key.
 [quest]
 requires_status=ak_temple_search
 requires_not=ak_temple_sealed
+requires_not=ak_talisman_used
 quest_text=Use the Averguard Key to enter the burial chamber deep within Averguard Temple.
 
 [quest]
@@ -53,7 +54,7 @@ requires_not=ak_talisman_reward
 quest_text=Show Langlier's Talisman to Guill.
 
 [quest]
-requires_status=ak_talisman_reward
+requires_status=ak_maddox_search
 requires_not=ak_maddox_defeated
 quest_text=Enter the Averguard Temple burial chamber and defeat Sir Evan Maddox.
 

--- a/tiled/averguard/averguard_temple.tmx
+++ b/tiled/averguard/averguard_temple.tmx
@@ -429,7 +429,7 @@
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 </data>
  </layer>
- <objectgroup name="event" width="28" height="129" visible="0">
+ <objectgroup name="event" width="28" height="129">
   <object type="teleport" x="448" y="4064" width="64" height="32">
    <properties>
     <property name="hotspot" value="14,128,2,1"/>
@@ -458,8 +458,8 @@
     <property name="hotspot" value="location"/>
     <property name="msg" value="You insert the Averguard Key. Runes glow around the door, then fade. The door is still sealed."/>
     <property name="requires_item" value="9001"/>
-    <property name="requires_not" value="ak_maddox_search"/>
-    <property name="requires_status" value="ak_temple_search"/>
+    <property name="requires_not" value="ak_talisman_found"/>
+    <property name="requires_status" value="ak_key_found"/>
     <property name="set_status" value="ak_temple_sealed"/>
     <property name="tooltip" value="Sealed Temple Door"/>
    </properties>
@@ -469,7 +469,7 @@
     <property name="hotspot" value="15,88,1,1"/>
     <property name="msg" value="You read aloud the runes on Langlier's Talisman. The Avergard Key begins to glow!"/>
     <property name="requires_not" value="ak_talisman_used"/>
-    <property name="requires_status" value="ak_maddox_search"/>
+    <property name="requires_status" value="ak_key_found,ak_talisman_found"/>
     <property name="set_status" value="ak_talisman_used"/>
     <property name="shakycam" value="60"/>
     <property name="soundfx" value="soundfx/powers/quake.ogg"/>


### PR DESCRIPTION
These changes remove the previous requirement of having to return to
Guill after finding the Key and the Talisman. Instead, players can
collect both items and head straight for Maddox. Then they only have to
make one trip back to Guill to get their rewards. Of course, they can
still return to Guill to turn those quests at any time in between.

Another change is the ability to grab both the Ukkonen and the Averguard
Tome quests at the same time.
