### PR TITLE
Adjust starting gold for classes based on new gear prices

### DIFF
--- a/mods/fantasycore/engine/classes.txt
+++ b/mods/fantasycore/engine/classes.txt
@@ -5,7 +5,7 @@
 [class]
 name=Brute
 description=Brutes rely on physical strength and melee weapons to strike down foes. Primary attribute: Physical
-currency=10
+currency=17
 equipment=64,66,67,32
 physical=1
 powers=5
@@ -14,7 +14,7 @@ actionbar=0,0,0,0,0,0,0,0,0,0,1,5
 [class]
 name=Adept
 description=Adepts have natural abilities in casting magical spells. Primary attribute: Mental
-currency=6
+currency=13
 equipment=64,66,67,40
 mental=1
 powers=6
@@ -24,7 +24,7 @@ actionbar=0,0,0,0,0,0,0,0,0,0,2,6
 [class]
 name=Scout
 description=Scouts specialize in range weaponry and combat accuracy. Primary attribute: Offense
-currency=12
+currency=21
 equipment=64,66,67,48
 offense=1
 powers=16
@@ -34,8 +34,8 @@ actionbar=0,0,0,0,0,0,0,0,0,0,22,16
 [class]
 name=Keeper
 description=Keepers focus on defensive powers for survival. Primary attribute: Defense
-currency=2
-equipment=81,83,84,56
+currency=7
+equipment=64,66,67,56
 defense=1
 powers=7
 actionbar=7,0,0,0,0,0,0,0,0,0,1,3
@@ -43,6 +43,6 @@ actionbar=7,0,0,0,0,0,0,0,0,0,1,3
 [class]
 name=Wanderer
 description=Wanderers choose their own paths. Primary attribute: custom
-currency=20
+currency=37
 equipment=64,66,67
 actionbar=0,0,0,0,0,0,0,0,0,0,1,0


### PR DESCRIPTION
Since the Wood Buckler costs more than any of the starting weapons by
itself, I've removed the set of leather armor from the Keeper to reduce
the gold differences between classes.
