### PR TITLE
Do not use fuzzy matching on .po updates

### DIFF
--- a/mods/fantasycore/languages/recreate_all_languages.sh
+++ b/mods/fantasycore/languages/recreate_all_languages.sh
@@ -5,6 +5,6 @@
 
 for f in $(ls *.po) ; do
 	echo "Processing $f"
-	msgmerge -U --no-wrap --no-fuzzy $f data.pot
+	msgmerge -U --no-wrap --no-fuzzy-matching $f data.pot
 done
 


### PR DESCRIPTION
By default `msgmerge` utility uses "fuzzy pattern matching" for added strings. If new string resembles existing string (from `msgmerge` point of view), then existing translation is used for it. Of course, in many cases translation will not be correct, but it may be used as a hint for translator. Such strings are marked as "fuzzy" - they are only suggestions and are not copied in resulting binary .mo message catalog. But since Flare does not use .mo catalogs and does not handle "fuzzy" tag, it uses these suggestions as translations. It is probably better to disable this feature, otherwise, unless checked by translator in time, translation will be left in poor state.
