### PR TITLE
Remove stash=true from the stash in frontier outpost. 

### DIFF
--- a/mods/alpha_demo/maps/frontier_outpost.txt
+++ b/mods/alpha_demo/maps/frontier_outpost.txt
@@ -269,7 +269,6 @@ type=stash
 location=22,28,1,1
 hotspot=location
 soundfx=soundfx/wood_open.ogg
-stash=true
 tooltip=Shared Stash
 
 [event]

--- a/tiled/frontier/frontier_outpost.tmx
+++ b/tiled/frontier/frontier_outpost.tmx
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="isometric" width="64" height="64" tilewidth="64" tileheight="32">
  <properties>
   <property name="music" value="unrest_theme.ogg"/>
@@ -261,7 +262,6 @@
    <properties>
     <property name="hotspot" value="location"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
-    <property name="stash" value="true"/>
     <property name="tooltip" value="Shared Stash"/>
    </properties>
   </object>


### PR DESCRIPTION
The property was unneeded as there was already specified type=stash
