### PR TITLE
Add repeat=false to books in Brothers' Lair maps

### DIFF
--- a/mods/alpha_demo/maps/brothers_lair_fire_hall.txt
+++ b/mods/alpha_demo/maps/brothers_lair_fire_hall.txt
@@ -371,6 +371,7 @@ location=19,16,1,1
 hotspot=location
 mapmod=object,19,16,165
 msg="Today Pompeii got a little over-excited to meet me and blew himself up. So I had to go into the caves and catch myself a NEW antlion burster. Again. I think I'm going to name this one 'Krakatoa'. ~Vesuvvio (the Destroyer)"
+repeat=false
 set_status=lb_fire_password
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand

--- a/mods/alpha_demo/maps/brothers_lair_ice_hall.txt
+++ b/mods/alpha_demo/maps/brothers_lair_ice_hall.txt
@@ -294,6 +294,7 @@ location=18,46,1,1
 hotspot=location
 mapmod=object,18,46,165
 msg="When we could no longer stand the idiotic practices of our master, I hatched a plan to kill him. My brothers agreed the deed had to be done."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -304,6 +305,7 @@ location=16,46,1,1
 hotspot=location
 mapmod=object,16,46,165
 msg="In accordance with our plan, G. asked the old fool to teach him about the preparation of corpses in the later stages of decay. Naturally, the corpse in question was a cleverly disguised bomb made by V."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -313,6 +315,7 @@ type=on_trigger
 location=25,60,1,1
 hotspot=location
 msg="My brothers and I wandered around for a few days. In an incredible stroke of luck, we encountered a master necromancer who, seeing the marks of banishment on our foreheads, took us as his apprentices."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Bookcase
 
@@ -323,6 +326,7 @@ location=30,48,1,1
 hotspot=location
 mapmod=object,30,48,165
 msg="We grew swiftly under the tutelage of the necromancer. The more we learned, the more we realized we could do better than the short-sighted git."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -333,6 +337,7 @@ location=7,51,1,1
 hotspot=location
 mapmod=object,7,51,164
 msg="My brothers V. and G. used to go to a wizard's academy with me. We were top students until one day V. killed another student in a spontaneous fit of rage."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -343,6 +348,7 @@ location=17,71,1,1
 hotspot=location
 mapmod=object,17,71,164
 msg="Naturally, V. was expelled for his crime. It was foolish of us, but G. and I decided to defend our brother. We were expelled too. The wizards magically marked us with a sign of banishment on our foreheads so that no wizard would dare teach us."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -353,6 +359,7 @@ location=16,10,1,1
 hotspot=location
 mapmod=object,16,10,165
 msg="G. suggested that each of us should take one of the halls in the old necromancer's lair."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -363,6 +370,7 @@ location=18,10,1,1
 hotspot=location
 mapmod=object,18,10,165
 msg="It's days like today that make me wonder if I should go a step further and eliminate V. and G. too... they're getting on my nerves. ~Scathelocke"
+repeat=false
 set_status=lb_ice_password
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand

--- a/mods/alpha_demo/maps/brothers_lair_wind_hall.txt
+++ b/mods/alpha_demo/maps/brothers_lair_wind_hall.txt
@@ -294,6 +294,7 @@ location=13,31,1,1
 hotspot=location
 mapmod=object,13,31,164
 msg="Fire is either Falling or Waiting. One element, one temperament."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -304,6 +305,7 @@ location=25,19,1,1
 hotspot=location
 mapmod=object,25,19,165
 msg="Wind is not Rising. Wind is Falling on the firmament."
+repeat=false
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand
 
@@ -322,6 +324,7 @@ location=31,8,1,1
 hotspot=location
 mapmod=object,31,8,164
 msg="People used to ask me why I use a sword rather than a wand. It never occurs to them that the metal blade can conduct and channel lightning as well as (or better than!) any enchanted twig. ~Grisbon"
+repeat=false
 set_status=lb_wind_password
 soundfx=soundfx/inventory/inventory_page.ogg
 tooltip=Book Stand

--- a/tiled/living_bones/brothers_lair_fire_hall.tmx
+++ b/tiled/living_bones/brothers_lair_fire_hall.tmx
@@ -295,9 +295,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,24,63,fixed,10,30"/>
     <property name="mapmod" value="object,23,64,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="704" y="2048" width="32" height="32">
@@ -305,9 +305,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,22,63,fixed,10,30"/>
     <property name="mapmod" value="object,22,64,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Crate" type="on_trigger" x="672" y="2048" width="32" height="32">
@@ -315,9 +315,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,21,63,fixed,10,35"/>
     <property name="mapmod" value="object,21,64,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Crate" type="on_trigger" x="736" y="2016" width="32" height="32">
@@ -325,9 +325,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,23,62,fixed,10,35"/>
     <property name="mapmod" value="object,23,63,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Burn Trap" type="on_trigger" x="672" y="640" width="32" height="32">
@@ -352,12 +352,12 @@
     <property name="loot" value="currency,22,60,fixed,100,200"/>
     <property name="mapmod" value="object,21,60,160"/>
     <property name="remove_item" value="9102"/>
+    <property name="repeat" value="false"/>
     <property name="requires_item" value="9102"/>
     <property name="set_status" value="lb_fire_looted"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Runed Chest"/>
     <property name="unset_status" value="lb_fire_key"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Vesuvvio's Chest Locked" type="on_trigger" x="672" y="1920" width="32" height="32">
@@ -375,6 +375,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,19,16,165"/>
     <property name="msg" value="&quot;Today Pompeii got a little over-excited to meet me and blew himself up. So I had to go into the caves and catch myself a NEW antlion burster. Again. I think I'm going to name this one 'Krakatoa'. ~Vesuvvio (the Destroyer)&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="set_status" value="lb_fire_password"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>

--- a/tiled/living_bones/brothers_lair_ice_hall.tmx
+++ b/tiled/living_bones/brothers_lair_ice_hall.tmx
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="isometric" width="50" height="80" tilewidth="64" tileheight="32" backgroundcolor="#000000">
  <properties>
   <property name="music" value="magical_theme.ogg"/>
@@ -306,6 +305,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,18,46,165"/>
     <property name="msg" value="&quot;When we could no longer stand the idiotic practices of our master, I hatched a plan to kill him. My brothers agreed the deed had to be done.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -315,6 +315,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,16,46,165"/>
     <property name="msg" value="&quot;In accordance with our plan, G. asked the old fool to teach him about the preparation of corpses in the later stages of decay. Naturally, the corpse in question was a cleverly disguised bomb made by V.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -323,6 +324,7 @@
    <properties>
     <property name="hotspot" value="location"/>
     <property name="msg" value="&quot;My brothers and I wandered around for a few days. In an incredible stroke of luck, we encountered a master necromancer who, seeing the marks of banishment on our foreheads, took us as his apprentices.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Bookcase"/>
    </properties>
@@ -332,6 +334,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,30,48,165"/>
     <property name="msg" value="&quot;We grew swiftly under the tutelage of the necromancer. The more we learned, the more we realized we could do better than the short-sighted git.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -341,6 +344,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,7,51,164"/>
     <property name="msg" value="&quot;My brothers V. and G. used to go to a wizard's academy with me. We were top students until one day V. killed another student in a spontaneous fit of rage.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -350,6 +354,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,17,71,164"/>
     <property name="msg" value="&quot;Naturally, V. was expelled for his crime. It was foolish of us, but G. and I decided to defend our brother. We were expelled too. The wizards magically marked us with a sign of banishment on our foreheads so that no wizard would dare teach us.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -359,6 +364,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,16,10,165"/>
     <property name="msg" value="&quot;G. suggested that each of us should take one of the halls in the old necromancer's lair.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -368,6 +374,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,18,10,165"/>
     <property name="msg" value="&quot;It's days like today that make me wonder if I should go a step further and eliminate V. and G. too... they're getting on my nerves. ~Scathelocke&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="set_status" value="lb_ice_password"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>

--- a/tiled/living_bones/brothers_lair_wind_hall.tmx
+++ b/tiled/living_bones/brothers_lair_wind_hall.tmx
@@ -200,9 +200,9 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="23,29,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Rising Wind Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Rising Fire Switch (Death)" type="on_trigger" x="800" y="928" width="32" height="32">
@@ -212,18 +212,18 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="25,29,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Rising Fire Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Rising Ice Switch (Left Door)" type="on_trigger" x="864" y="928" width="32" height="32">
    <properties>
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,10,31,112;collision,10,31,0;object,27,29,166"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Rising Ice Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Falling Ice Switch (Death)" type="on_trigger" x="864" y="992" width="32" height="32">
@@ -233,18 +233,18 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="27,31,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Falling Ice Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Falling Wind Switch (Right Door)" type="on_trigger" x="736" y="992" width="32" height="32">
    <properties>
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,23,31,166;object,25,16,113;collision,25,16,0"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Falling Wind Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Falling Fire Switch (Death)" type="on_trigger" x="800" y="992" width="32" height="32">
@@ -254,9 +254,9 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="25,31,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Falling Fire Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Waiting Wind Switch (Death)" type="on_trigger" x="736" y="1056" width="32" height="32">
@@ -266,9 +266,9 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="23,33,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Waiting Wind Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Waiting Fire Switch (Treasure)" type="on_trigger" x="800" y="1056" width="32" height="32">
@@ -276,9 +276,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,25,34,fixed,10,50"/>
     <property name="mapmod" value="object,25,33,166"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Waiting Fire Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Waiting Ice Switch (Death)" type="on_trigger" x="864" y="1056" width="32" height="32">
@@ -288,9 +288,9 @@
     <property name="power" value="6"/>
     <property name="power_damage" value="1000,1000"/>
     <property name="power_path" value="27,33,hero"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/door_open.ogg"/>
     <property name="tooltip" value="Waiting Ice Switch"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Storage Room Clue Book" type="on_trigger" x="416" y="992" width="32" height="32">
@@ -298,6 +298,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,13,31,164"/>
     <property name="msg" value="&quot;Fire is either Falling or Waiting. One element, one temperament.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -307,6 +308,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,25,19,165"/>
     <property name="msg" value="&quot;Wind is not Rising. Wind is Falling on the firmament.&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
    </properties>
@@ -323,6 +325,7 @@
     <property name="hotspot" value="location"/>
     <property name="mapmod" value="object,31,8,164"/>
     <property name="msg" value="&quot;People used to ask me why I use a sword rather than a wand. It never occurs to them that the metal blade can conduct and channel lightning as well as (or better than!) any enchanted twig. ~Grisbon&quot;"/>
+    <property name="repeat" value="false"/>
     <property name="set_status" value="lb_wind_password"/>
     <property name="soundfx" value="soundfx/inventory/inventory_page.ogg"/>
     <property name="tooltip" value="Book Stand"/>
@@ -333,9 +336,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,31,14,fixed,15,30"/>
     <property name="mapmod" value="object,31,15,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Crate" type="on_trigger" x="1152" y="448" width="32" height="32">
@@ -343,9 +346,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,35,13,fixed,15,30"/>
     <property name="mapmod" value="object,36,14,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Crate" type="on_trigger" x="352" y="1472" width="32" height="32">
@@ -353,9 +356,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,11,45,fixed,15,30"/>
     <property name="mapmod" value="object,11,46,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Crate" type="on_trigger" x="96" y="1472" width="32" height="32">
@@ -363,9 +366,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,4,45,fixed,15,30"/>
     <property name="mapmod" value="object,3,46,163"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Crate"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="96" y="1440" width="32" height="32">
@@ -373,9 +376,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,3,44,fixed,15,30"/>
     <property name="mapmod" value="object,3,45,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="128" y="1472" width="32" height="32">
@@ -383,9 +386,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,5,46,fixed,15,30"/>
     <property name="mapmod" value="object,4,46,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="320" y="1472" width="32" height="32">
@@ -393,9 +396,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,9,46,fixed,15,30"/>
     <property name="mapmod" value="object,10,46,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="352" y="1408" width="32" height="32">
@@ -403,9 +406,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,10,44,fixed,15,30"/>
     <property name="mapmod" value="object,11,44,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Barrel" type="on_trigger" x="1152" y="480" width="32" height="32">
@@ -413,9 +416,9 @@
     <property name="hotspot" value="location"/>
     <property name="loot" value="currency,35,14,fixed,15,30"/>
     <property name="mapmod" value="object,36,15,162"/>
+    <property name="repeat" value="false"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Barrel"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Grisbon's Chest" type="on_trigger" x="992" y="224" width="32" height="32">
@@ -424,12 +427,12 @@
     <property name="loot" value="currency,32,7,fixed,100,200"/>
     <property name="mapmod" value="object,31,7,160"/>
     <property name="remove_item" value="9103"/>
+    <property name="repeat" value="false"/>
     <property name="requires_item" value="9103"/>
     <property name="set_status" value="lb_wind_looted"/>
     <property name="soundfx" value="soundfx/wood_open.ogg"/>
     <property name="tooltip" value="Runed Chest"/>
     <property name="unset_status" value="lb_wind_key"/>
-    <property name="repeat" value="false"/>
    </properties>
   </object>
   <object name="Grisbon's Chest Locked" type="on_trigger" x="992" y="224" width="32" height="32">


### PR DESCRIPTION
This fixes a bug where the player couldn't get past the bookcase door in
the Ice Hall. Previously, pressing ACCEPT near that door would
continuously trigger one of the two nearby books.
