### PR TITLE
Fix warnings for unknown keys

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1,4 +1,4 @@
-F# Power Definitions
+# Power Definitions
 
 [power]
 id=1
@@ -425,7 +425,7 @@ trait_elemental=air
 starting_pos=target
 multitarget=true
 post_power=126
-range=8.0
+target_range=8.0
 post_effect=203,0,45
 
 [power]


### PR DESCRIPTION
When starting a new game I got the following warnings printed in the terminal:
ignoring unknown key  set to  in file ./mods/fantasycore/powers/powers.txt
ignoring unknown key range set to 0 in file ./mods/fantasycore/powers/powers.txt

The first is due to the (presumably) accidental 'F' in front of the comment/headline. The second one was fixed by changing Thunderstrike's range to target_range.
