### PR TITLE
Adjust Aether Walkers to be Æther Walkers in item db

### DIFF
--- a/mods/fantasycore/items/items.txt
+++ b/mods/fantasycore/items/items.txt
@@ -937,7 +937,7 @@ price=125
 
 [item]
 id=126
-name=Aether Walkers
+name=Æther Walkers
 quality=epic
 item_type=feet
 icon=176


### PR DESCRIPTION
Fixes #374
