### PR TITLE
Remove some obsolete keys from various data files

### DIFF
--- a/mods/alpha_demo/npcs/kayl.txt
+++ b/mods/alpha_demo/npcs/kayl.txt
@@ -7,10 +7,6 @@ constant_stock=1,1,1,2,2,2,40,41,42,72,73,74,75,76
 
 # animation info
 gfx=animations/npcs/peasant_woman2.txt
-render_size=128,128
-render_offset=64,96
-anim_frames=1
-anim_duration=30
 
 # voiceover files
 vox_intro=soundfx/npcs/female_merchant_05.ogg

--- a/mods/fantasycore/engine/loot.txt
+++ b/mods/fantasycore/engine/loot.txt
@@ -3,15 +3,10 @@
 # Sound effects
 sfx_loot=soundfx/flying_loot.ogg
 
-# Animation
-loot_animation=0,0,64,128
-loot_animation_offset=32,112
-
 # Tooltip
 tooltip_margin=32
 
 # Autopickup
-autopickup_range=1.5
 autopickup_currency=1
 
 # Currency

--- a/mods/fantasycore/engine/tileset_config.txt
+++ b/mods/fantasycore/engine/tileset_config.txt
@@ -1,7 +1,4 @@
 # Tileset Settings
 orientation=isometric
-# units_per_tile MUST be a power of 2
-# and divisible by both tile dimensions
-units_per_tile=64
 # tile_size: width, height
 tile_size=64,32

--- a/mods/fantasycore/menus/actionbar.txt
+++ b/mods/fantasycore/menus/actionbar.txt
@@ -4,8 +4,6 @@
 pos=0,0,640,35
 align=bottom
 
-default_M1_power=1
-
 slot1=32,3,32,32
 slot2=64,3,32,32
 slot3=96,3,32,32

--- a/mods/fantasycore/menus/character.txt
+++ b/mods/fantasycore/menus/character.txt
@@ -43,7 +43,6 @@ unspent=160,396,center,top
 # item visibility
 # these are boolean. 0 to hide, 1 to show
 
-show_unspent=1
 show_upgrade_physical=1
 show_upgrade_mental=1
 show_upgrade_offense=1

--- a/mods/fantasycore/menus/log.txt
+++ b/mods/fantasycore/menus/log.txt
@@ -11,5 +11,4 @@ label_title=160,8,center,top
 close=294,2
 
 tab_area=32,30,241,336
-tab_bg_color=42,40,38
 

--- a/mods/fantasycore/menus/talker.txt
+++ b/mods/fantasycore/menus/talker.txt
@@ -7,7 +7,6 @@ align=center
 
 close=608,320
 advance=608,320
-vendor=466,288
 dialogbox=0,320,640,96
 dialogtext=32,320,576,96
 text_offset=16,16

--- a/mods/minicore/engine/loot.txt
+++ b/mods/minicore/engine/loot.txt
@@ -1,21 +1,4 @@
-# Loot settings
-
-loot_animation=0,0,32,64
-loot_animation_offset=16,56
+APPEND
 
 tooltip_margin=16
 
-# Autopickup
-autopickup_range=1.5
-autopickup_currency=1
-
-# Currency
-currency_name=Gold
-vendor_ratio=25
-
-# currency loot ranges
-# values are: filename, lower limit, upper limit
-# -1 can be used for the upper limit to set no upper limit
-currency_range=coins5,0,9
-currency_range=coins25,10,24
-currency_range=coins100,25,-1

--- a/mods/minicore/engine/tileset_config.txt
+++ b/mods/minicore/engine/tileset_config.txt
@@ -1,7 +1,4 @@
 # Tileset Settings
 orientation=isometric
-# units_per_tile MUST be a power of 2
-# and divisible by both tile dimensions
-units_per_tile=64
 # tile_size: width, height
 tile_size=32,16

--- a/mods/minicore/menus/actionbar.txt
+++ b/mods/minicore/menus/actionbar.txt
@@ -4,8 +4,6 @@
 pos=0,0,320,18
 align=bottom
 
-default_M1_power=1
-
 slot1=16,1,16,16
 slot2=32,1,16,16
 slot3=48,1,16,16

--- a/mods/minicore/menus/character.txt
+++ b/mods/minicore/menus/character.txt
@@ -41,7 +41,6 @@ unspent=48,53,80,8
 # item visibility
 # these are boolean. 0 to hide, 1 to show
 
-show_unspent=1
 show_upgrade_physical=1
 show_upgrade_mental=1
 show_upgrade_offense=1

--- a/mods/minicore/menus/log.txt
+++ b/mods/minicore/menus/log.txt
@@ -11,5 +11,4 @@ label_title=80,4,center,top
 close=147,1
 
 tab_area=16,15,120,168
-tab_bg_color=42,40,38
 

--- a/mods/minicore/menus/talker.txt
+++ b/mods/minicore/menus/talker.txt
@@ -7,7 +7,6 @@ align=center
 
 close=304,144
 advance=304,144
-vendor=233,128
 dialogbox=0,144,320,64
 dialogtext=16,144,288,64
 text_offset=2,1


### PR DESCRIPTION
Note: maps still complain about 'tilewidth' and 'tileheight'. These are
indeed obsolete, but we should patch the Flare plugin for Tiled before
removing them here. Otherwise, we'll probably add them again by
accident.
