### PR TITLE
fix: use HTTPS URLs in AppStream metadata

### DIFF
--- a/distribution/org.flarerpg.Flare.appdata.xml
+++ b/distribution/org.flarerpg.Flare.appdata.xml
@@ -18,34 +18,34 @@
 		<p>The Flare engine is licensed under GPL 3, whereas the Empyrean Campaign is licensed under CC-BY-SA 3.0. Both the engine and the game content are being actively developed, including new features, art, and content.</p>
 	</description>
 	<launchable type="desktop-id">flare.desktop</launchable>
-	<url type="homepage">http://flarerpg.org/</url>
+	<url type="homepage">https://flarerpg.org/</url>
 	<releases>
 		<release date="2026-05-08" version="1.15" />
 	</releases>
 	<screenshots>
 		<screenshot type="default">
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_1.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_1.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_2.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_2.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_3.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_3.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_4.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_4.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_5.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_5.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_6.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_6.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_7.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_7.jpg</image>
 		</screenshot>
 		<screenshot>
-			<image type="source">http://flarerpg.org/wp-content/uploads/2026/05/empyrean_8.jpg</image>
+			<image type="source">https://flarerpg.org/wp-content/uploads/2026/05/empyrean_8.jpg</image>
 		</screenshot>
 	</screenshots>
 	<content_rating type="oars-1.1">


### PR DESCRIPTION
## Summary

- Use HTTPS for the Flare homepage in AppStream metadata.
- Use HTTPS for the AppStream screenshot URLs.
- Leave the rest of the metadata unchanged.

## Testing

- Ran `git diff --check`
- Parsed `distribution/org.flarerpg.Flare.appdata.xml` with Python's XML parser
- Confirmed `https://flarerpg.org/` returns HTTP 200
- Confirmed `https://flarerpg.org/wp-content/uploads/2026/05/empyrean_1.jpg` returns HTTP 200
