### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

- Add a root `.editorconfig` for common text editor settings.
- Preserve the repository's existing CRLF line ending convention.
- Set Markdown/YAML and CMake indentation to spaces.

## Testing

- Ran `git diff --check`
- Verified `.editorconfig` is UTF-8
- Verified it uses CRLF line endings
- Verified it ends with a final newline
