### PR TITLE
docs: use HTTPS for homepage link in README

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ The Marck Script font is licensed under the SIL Open Font License, Version 1.1.
 
 ## Links
 
-* [Homepage](http://flarerpg.org)
+* [Homepage](https://flarerpg.org)
 * [Source](https://github.com/flareteam/flare-game)
 * [Binaries](https://github.com/flareteam/flare-game/releases)
 * [Binaries (mirror)](https://sourceforge.net/projects/flare-game/)


### PR DESCRIPTION
## Summary

- Update the Homepage link in `README` from `http://flarerpg.org` to `https://flarerpg.org`

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
- Verified `https://flarerpg.org` returns HTTP 200
